### PR TITLE
Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,7 +57,7 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/pycqa/bandit
-    rev: 1.7.10
+    rev: 1.8.0
     hooks:
       - id: bandit
         args:
@@ -66,7 +66,7 @@ repos:
           - "--exclude"
           - "tests"
   - repo: https://github.com/pycqa/bandit
-    rev: 1.7.10
+    rev: 1.8.0
     hooks:
       - id: bandit
         args:


### PR DESCRIPTION
Update versions of pre-commit hooks to latest version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the `bandit` security linter tool to version `1.8.0`, potentially improving security checks.
	- Set the default Python version for hooks to `python3.11` for enhanced compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->