### PR TITLE
Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,7 +57,7 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/pycqa/bandit
-    rev: 1.8.0
+    rev: 1.8.2
     hooks:
       - id: bandit
         args:
@@ -66,7 +66,7 @@ repos:
           - "--exclude"
           - "tests"
   - repo: https://github.com/pycqa/bandit
-    rev: 1.8.0
+    rev: 1.8.2
     hooks:
       - id: bandit
         args:


### PR DESCRIPTION
Update versions of pre-commit hooks to latest version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated pre-commit `bandit` hook to version 1.8.2 for improved security scanning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->