### PR TITLE
Clean up: remove leftover Python code and configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,141 +1,16 @@
-# Byte-compiled / optimized / DLL files
-__pycache__/
-*.py[cod]
-*$py.class
-
-# C extensions
+# Build artifacts
 *.so
+/target
 
-# Distribution / packaging
-.Python
-build/
-develop-eggs/
-dist/
-downloads/
-eggs/
-.eggs/
-lib/
-lib64/
-parts/
-sdist/
-var/
-wheels/
-pip-wheel-metadata/
-share/python-wheels/
-*.egg-info/
-.installed.cfg
-*.egg
-MANIFEST
-
-# PyInstaller
-#  Usually these files are written by a python script from a template
-#  before PyInstaller builds the exe, so as to inject date/other infos into it.
-*.manifest
-*.spec
-
-# Installer logs
-pip-log.txt
-pip-delete-this-directory.txt
-
-# Unit test / coverage reports
-htmlcov/
-.tox/
-.nox/
-.coverage
-.coverage.*
-.cache
-nosetests.xml
-coverage.xml
-*.cover
-*.py,cover
-.hypothesis/
-.pytest_cache/
-
-# Translations
-*.mo
-*.pot
-
-# Django stuff:
-*.log
-local_settings.py
-db.sqlite3
-db.sqlite3-journal
-
-# Flask stuff:
-instance/
-.webassets-cache
-
-# Scrapy stuff:
-.scrapy
-
-# Sphinx documentation
-docs/_build/
-
-# PyBuilder
-target/
-
-# Jupyter Notebook
-.ipynb_checkpoints
-
-# IPython
-profile_default/
-ipython_config.py
-
-# pyenv
-.python-version
-
-# pipenv
-#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
-#   However, in case of collaboration, if having platform-specific dependencies or dependencies
-#   having no cross-platform support, pipenv may install dependencies that don't work, or not
-#   install all needed dependencies.
-#Pipfile.lock
-
-# PEP 582; used by e.g. github.com/David-OConnor/pyflow
-__pypackages__/
-
-# Celery stuff
-celerybeat-schedule
-celerybeat.pid
-
-# SageMath parsed files
-*.sage.py
-
-# Environments
+# Environment
 .env
-.venv
-env/
-venv/
-ENV/
-env.bak/
-venv.bak/
 
-# Spyder project settings
-.spyderproject
-.spyproject
-
-# Rope project settings
-.ropeproject
-
-# mkdocs documentation
-/site
-
-# mypy
-.mypy_cache/
-.dmypy.json
-dmypy.json
-
-# Pyre type checker
-.pyre/
-
-# VSCode
+# Editor
 .vscode/
 
-# pytest-testmon
-.testmondata*
+# OS
 .DS_Store
 
-
-# Added by cargo
-
-/target
+# Generic
+*.log
+.cache

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,0 @@
-mypy:
-	poetry run mypy .
-
-test:
-	poetry run pytest -x --cov=core --cov=tech_debt_hotspot --cov-fail-under=89
-
-install:
-	poetry install --sync

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Unit testing, formatting & linting](https://github.com/expobrain/tech_debt_hotspot/actions/workflows/testing-formatting-linting.yml/badge.svg)](https://github.com/expobrain/tech_debt_hotspot/actions/workflows/testing-formatting-linting.yml)
 
-A tool to identify hotspots of tech debt in a Python codebase.
+A tool to identify hotspots of tech debt in a codebase.
 
 ⚠️ **WARNING**: The binary of this tool is not signed so on OSX it will raise a warning. See the official [instructions](https://support.apple.com/en-gb/guide/mac-help/mh40616/mac) to allow the execution of unsigned binaries on OSX.
 
@@ -10,15 +10,11 @@ A tool to identify hotspots of tech debt in a Python codebase.
 
 This tools collects the maintainability index and the number of changes in the repository for each file of the codebase and aggregated for each package and outputs a CSV with:
 
-- **path**: the path of the Python module or package
+- **path**: the path of the module or package
 - **path_type**: the type of the path (module or package)
 - **maintainability_index**: the maintainability index of the module or package calulated by using the Visual Studio's [formula](https://learn.microsoft.com/en-us/visualstudio/code-quality/code-metrics-maintainability-index-range-and-meaning)
 - **changes**: the number of changes in the module or package from the version control
 - **hotspot_score**: the inverse of the number of changes over the maintainability index
-
-## Language supported
-
-The tool currently supports only Python.
 
 ## Usage
 


### PR DESCRIPTION
## Summary

Removes vestigial Python code and configuration left over from the project's original Python implementation (before the Rust rewrite). The core Rust logic that parses Python files (`rustpython-parser`, `PythonParser`) is preserved — this only removes **leftover** Python artifacts.

### Changes

- **Delete Makefile** — contained stale targets (`mypy`, `poetry run pytest`, `poetry install`) for the old Python toolchain
- **Strip `.gitignore`** — reduced from 141 lines (Python template with Django, Flask, pytest, mypy, pyenv, pipenv, Celery, etc.) to a minimal Rust-relevant gitignore
- **Update README.md** — removed Python-specific phrasing ("Python codebase" → "codebase", "Python module" → "module", removed redundant "Language supported" section)

### Preserved

- `pre-commit` config and CI (pre-commit is a Python tool, but still used for Rust linting)
- `rustpython-parser` and `PythonParser` in `src/hotspot.rs` (core tool functionality — parsing Python files for metrics)