### PR TITLE
fix: replace sort_unstable_by with sort_unstable_by_key to fix clippy warnings

### DIFF
--- a/src/hotspot.rs
+++ b/src/hotspot.rs
@@ -163,7 +163,7 @@ impl TechDebtHotspots {
     }
 
     fn get_stats_from_filenames(&mut self) -> &mut Self {
-        for (_, file_stats) in self.stats.iter_mut() {
+        for file_stats in self.stats.values_mut() {
             Self::get_stats_from_filename(file_stats);
         }
 
@@ -198,7 +198,7 @@ impl TechDebtHotspots {
     }
 
     fn normalise_to_git_root(&mut self) -> &mut Self {
-        for (_, file_stats) in self.stats.iter_mut() {
+        for file_stats in self.stats.values_mut() {
             let path = Path::new(&file_stats.path).to_path_buf();
             let relative_path = path.strip_prefix(&self.git_base_path);
 

--- a/src/sorting.rs
+++ b/src/sorting.rs
@@ -83,7 +83,7 @@ pub fn sort_stats_by(mut stats: Vec<HotspotStats>, sort_by: SortBy) -> Vec<Hotsp
             });
         }
         SortBy::LinesOfCode => {
-            stats.sort_unstable_by(|a, b| b.loc.cmp(&a.loc));
+            stats.sort_unstable_by_key(|b| std::cmp::Reverse(b.loc));
         }
         SortBy::CommentsPercentage => {
             stats.sort_unstable_by(|a, b| {
@@ -93,7 +93,7 @@ pub fn sort_stats_by(mut stats: Vec<HotspotStats>, sort_by: SortBy) -> Vec<Hotsp
             });
         }
         SortBy::ChangesCount => {
-            stats.sort_unstable_by(|a, b| b.changes_count.cmp(&a.changes_count));
+            stats.sort_unstable_by_key(|b| std::cmp::Reverse(b.changes_count));
         }
         SortBy::HotspotIndex => {
             stats.sort_unstable_by(|a, b| {


### PR DESCRIPTION
Replace sort_unstable_by with sort_unstable_by_key using std::cmp::Reverse to fix clippy::unnecessary_sort_by warnings.