### PR TITLE
feat: add JavaScript and TypeScript support to hotspot analysis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,18 +3,6 @@
 version = 4
 
 [[package]]
-name = "ahash"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -90,12 +78,6 @@ dependencies = [
  "once_cell",
  "windows-sys",
 ]
-
-[[package]]
-name = "anyhow"
-version = "1.0.95"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
 name = "arrayvec"
@@ -267,12 +249,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
-name = "crunchy"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
-
-[[package]]
 name = "csv"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -292,33 +268,6 @@ checksum = "7d02f3b0da4c6504f86e9cd789d8dbafab48c2321be74e9987593de5a894d93d"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "derive_more"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
-dependencies = [
- "derive_more-impl",
-]
-
-[[package]]
-name = "derive_more-impl"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.98",
- "unicode-xid",
-]
-
-[[package]]
-name = "either"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "equivalent"
@@ -407,26 +356,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "getopts"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
-dependencies = [
- "unicode-width 0.1.11",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -434,7 +363,7 @@ checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.13.3+wasi-0.2.2",
+ "wasi",
  "windows-targets",
 ]
 
@@ -455,15 +384,6 @@ dependencies = [
  "log",
  "regex-automata",
  "regex-syntax",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
 ]
 
 [[package]]
@@ -508,19 +428,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.2",
-]
-
-[[package]]
-name = "is-macro"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d57a3e447e24c22647738e4607f1df1e0ec6f72e16182c4cd199f647cdfb0e4"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn 2.0.98",
+ "hashbrown",
 ]
 
 [[package]]
@@ -528,15 +436,6 @@ name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
-
-[[package]]
-name = "itertools"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itoa"
@@ -555,12 +454,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lalrpop-util"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -573,12 +466,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
-name = "libm"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -589,64 +476,6 @@ name = "log"
 version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
-
-[[package]]
-name = "malachite"
-version = "0.4.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fbdf9cb251732db30a7200ebb6ae5d22fe8e11397364416617d2c2cf0c51cb5"
-dependencies = [
- "malachite-base",
- "malachite-nz",
- "malachite-q",
-]
-
-[[package]]
-name = "malachite-base"
-version = "0.4.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea0ed76adf7defc1a92240b5c36d5368cfe9251640dcce5bd2d0b7c1fd87aeb"
-dependencies = [
- "hashbrown 0.14.5",
- "itertools",
- "libm",
- "ryu",
-]
-
-[[package]]
-name = "malachite-bigint"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d149aaa2965d70381709d9df4c7ee1fc0de1c614a4efc2ee356f5e43d68749f8"
-dependencies = [
- "derive_more",
- "malachite",
- "num-integer",
- "num-traits",
- "paste",
-]
-
-[[package]]
-name = "malachite-nz"
-version = "0.4.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34a79feebb2bc9aa7762047c8e5495269a367da6b5a90a99882a0aeeac1841f7"
-dependencies = [
- "itertools",
- "libm",
- "malachite-base",
-]
-
-[[package]]
-name = "malachite-q"
-version = "0.4.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f235d5747b1256b47620f5640c2a17a88c7569eebdf27cd9cb130e1a619191"
-dependencies = [
- "itertools",
- "malachite-base",
- "malachite-nz",
-]
 
 [[package]]
 name = "memchr"
@@ -762,14 +591,8 @@ checksum = "6978128c8b51d8f4080631ceb2302ab51e32cc6e8615f735ee2f83fd269ae3f1"
 dependencies = [
  "bytecount",
  "fnv",
- "unicode-width 0.2.0",
+ "unicode-width",
 ]
-
-[[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "petgraph"
@@ -779,44 +602,6 @@ checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
  "indexmap",
-]
-
-[[package]]
-name = "phf"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
-dependencies = [
- "phf_shared",
-]
-
-[[package]]
-name = "phf_codegen"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
-dependencies = [
- "phf_generator",
- "phf_shared",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
-dependencies = [
- "phf_shared",
- "rand",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
-dependencies = [
- "siphasher",
 ]
 
 [[package]]
@@ -830,15 +615,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "ppv-lite86"
-version = "0.2.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
-dependencies = [
- "zerocopy",
-]
 
 [[package]]
 name = "proc-macro-crate"
@@ -887,36 +663,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "rand"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
-dependencies = [
- "libc",
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -1017,12 +763,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1042,63 +782,6 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys",
-]
-
-[[package]]
-name = "rustpython-ast"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cdaf8ee5c1473b993b398c174641d3aa9da847af36e8d5eb8291930b72f31a5"
-dependencies = [
- "is-macro",
- "malachite-bigint",
- "rustpython-parser-core",
- "static_assertions",
-]
-
-[[package]]
-name = "rustpython-parser"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "868f724daac0caf9bd36d38caf45819905193a901e8f1c983345a68e18fb2abb"
-dependencies = [
- "anyhow",
- "is-macro",
- "itertools",
- "lalrpop-util",
- "log",
- "malachite-bigint",
- "num-traits",
- "phf",
- "phf_codegen",
- "rustc-hash",
- "rustpython-ast",
- "rustpython-parser-core",
- "tiny-keccak",
- "unic-emoji-char",
- "unic-ucd-ident",
- "unicode_names2",
-]
-
-[[package]]
-name = "rustpython-parser-core"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4b6c12fa273825edc7bccd9a734f0ad5ba4b8a2f4da5ff7efe946f066d0f4ad"
-dependencies = [
- "is-macro",
- "memchr",
- "rustpython-parser-vendored",
-]
-
-[[package]]
-name = "rustpython-parser-vendored"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04fcea49a4630a3a5d940f4d514dc4f575ed63c14c3e3ed07146634aed7f67a6"
-dependencies = [
- "memchr",
- "once_cell",
 ]
 
 [[package]]
@@ -1155,12 +838,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "siphasher"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
-
-[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1168,12 +845,6 @@ checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
 dependencies = [
  "autocfg",
 ]
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -1236,7 +907,6 @@ dependencies = [
  "csv",
  "rstest",
  "rust-code-analysis",
- "rustpython-parser",
  "tabled",
  "tempfile",
 ]
@@ -1248,7 +918,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.1",
+ "getrandom",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -1269,16 +939,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f8daae29995a24f65619e19d8d31dea5b389f3d853d8bf297bbf607cd0014cc"
 dependencies = [
- "unicode-width 0.2.0",
-]
-
-[[package]]
-name = "tiny-keccak"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
-dependencies = [
- "crunchy",
+ "unicode-width",
 ]
 
 [[package]]
@@ -1411,68 +1072,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "unic-char-property"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8c57a407d9b6fa02b4795eb81c5b6652060a15a7903ea981f3d723e6c0be221"
-dependencies = [
- "unic-char-range",
-]
-
-[[package]]
-name = "unic-char-range"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0398022d5f700414f6b899e10b8348231abf9173fa93144cbc1a43b9793c1fbc"
-
-[[package]]
-name = "unic-common"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d7ff825a6a654ee85a63e80f92f054f904f21e7d12da4e22f9834a4aaa35bc"
-
-[[package]]
-name = "unic-emoji-char"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b07221e68897210270a38bde4babb655869637af0f69407f96053a34f76494d"
-dependencies = [
- "unic-char-property",
- "unic-char-range",
- "unic-ucd-version",
-]
-
-[[package]]
-name = "unic-ucd-ident"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e230a37c0381caa9219d67cf063aa3a375ffed5bf541a452db16e744bdab6987"
-dependencies = [
- "unic-char-property",
- "unic-char-range",
- "unic-ucd-version",
-]
-
-[[package]]
-name = "unic-ucd-version"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4"
-dependencies = [
- "unic-common",
-]
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
 name = "unicode-width"
@@ -1481,44 +1084,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unicode_names2"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1673eca9782c84de5f81b82e4109dcfb3611c8ba0d52930ec4a9478f547b2dd"
-dependencies = [
- "phf",
- "unicode_names2_generator",
-]
-
-[[package]]
-name = "unicode_names2_generator"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91e5b84611016120197efd7dc93ef76774f4e084cd73c9fb3ea4a86c570c56e"
-dependencies = [
- "getopts",
- "log",
- "phf_codegen",
- "rand",
-]
-
-[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"
@@ -1529,12 +1098,6 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi"
@@ -1716,25 +1279,4 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
 dependencies = [
  "bitflags",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
-dependencies = [
- "byteorder",
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.98",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ chrono = "0.4.44"
 clap = { version = "4.6.1", features = ["cargo"] }
 csv = "1.3.1"
 rust-code-analysis = "0.0.25"
-rustpython-parser = "0.4.0"
 tabled = "0.20.0"
 
 [dev-dependencies]

--- a/src/hotspot.rs
+++ b/src/hotspot.rs
@@ -1,7 +1,6 @@
 use chrono::NaiveDate;
 use core::panic;
-use rust_code_analysis::ParserTrait;
-use rust_code_analysis::{metrics, PythonParser};
+use rust_code_analysis::{get_function_spaces, LANG};
 use std::path::PathBuf;
 use std::{collections::HashMap, fs, path::Path, process::Command};
 use tabled::Tabled;
@@ -46,6 +45,16 @@ impl HotspotStats {
             changes_count: file_stats.changes_count,
             hotspot_index,
         }
+    }
+}
+
+fn extension_to_lang(ext: &str) -> Option<LANG> {
+    match ext {
+        "py" => Some(LANG::Python),
+        "js" | "mjs" | "jsx" => Some(LANG::Javascript),
+        "ts" => Some(LANG::Typescript),
+        "tsx" => Some(LANG::Tsx),
+        _ => None,
     }
 }
 
@@ -97,7 +106,11 @@ impl TechDebtHotspots {
                         paths_to_visit.push(path_to_visit);
                     });
                 }
-                false if current_path.extension().and_then(|s| s.to_str()) == Some("py") => {
+                false if current_path
+                    .extension()
+                    .and_then(|s| s.to_str())
+                    .and_then(extension_to_lang)
+                    .is_some() => {
                     self.stats.insert(
                         current_path.to_path_buf(),
                         FileStats {
@@ -173,9 +186,10 @@ impl TechDebtHotspots {
     fn get_stats_from_filename(file_stats: &mut FileStats) {
         let path = Path::new(&file_stats.path).to_path_buf();
         let source_code = fs::read(path.clone()).unwrap();
-        let parser = PythonParser::new(source_code, &path, None);
+        let ext = path.extension().and_then(|s| s.to_str()).unwrap_or("");
+        let lang = extension_to_lang(ext).unwrap();
 
-        if let Some(s) = metrics(&parser, &path) {
+        if let Some(s) = get_function_spaces(&lang, source_code, &path, None) {
             let sloc = s.metrics.loc.sloc();
 
             match sloc {
@@ -271,11 +285,10 @@ mod tests {
     }
 
     #[fixture]
-    fn git_repo_with_files() -> (TempDir, PathBuf, PathBuf) {
+    fn git_repo_with_files() -> (TempDir, Vec<PathBuf>) {
         let temp_dir = tempdir().unwrap();
         let temp_path = temp_dir.path();
 
-        // Create a Git directory structure with some Python files
         let sub_dir = temp_path.join("subdir");
         fs::create_dir(&sub_dir).unwrap();
 
@@ -285,18 +298,25 @@ mod tests {
             .output()
             .expect("Failed to initialize Git repository");
 
-        let file1 = temp_path.join("file1.py");
-        let file2 = sub_dir.join("file2.py");
-        fs::write(&file1, "print('Hello, world!')").unwrap();
-        fs::write(&file2, "print('Hello, subdir!')").unwrap();
+        let py_file = temp_path.join("file1.py");
+        let js_file = sub_dir.join("file2.js");
+        let ts_file = temp_path.join("file3.ts");
+        let tsx_file = sub_dir.join("file4.tsx");
+        let txt_file = temp_path.join("readme.txt");
 
-        (temp_dir, file1.to_path_buf(), file2.to_path_buf())
+        fs::write(&py_file, "print('Hello, world!')").unwrap();
+        fs::write(&js_file, "const x = 1;").unwrap();
+        fs::write(&ts_file, "const x: number = 1;").unwrap();
+        fs::write(&tsx_file, "const x: number = 1;").unwrap();
+        fs::write(&txt_file, "just text").unwrap();
+
+        (temp_dir, vec![py_file, js_file, ts_file, tsx_file])
     }
 
     #[rstest]
-    fn test_collect_filenames(git_repo_with_files: (TempDir, PathBuf, PathBuf)) {
+    fn test_collect_filenames(git_repo_with_files: (TempDir, Vec<PathBuf>)) {
         // ARRANGE
-        let (temp_dir, file1, file2) = git_repo_with_files;
+        let (temp_dir, supported_files) = git_repo_with_files;
 
         // ACT
         let mut tech_debt_hotspots = TechDebtHotspots::new(temp_dir.path(), None, None);
@@ -305,23 +325,31 @@ mod tests {
         let actual = tech_debt_hotspots.stats;
 
         // ASSERT
-        let mut expected = HashMap::new();
-        expected.insert(
-            file1.clone(),
-            FileStats {
-                path: file1.clone(),
-                ..Default::default()
-            },
-        );
-        expected.insert(
-            file2.clone(),
-            FileStats {
-                path: file2.clone(),
-                ..Default::default()
-            },
-        );
+        assert_eq!(actual.len(), 4);
 
-        assert_eq!(actual, expected);
+        for path in &supported_files {
+            assert!(actual.contains_key(path), "Missing: {}", path.display());
+        }
+    }
+
+    #[rstest]
+    fn test_extension_to_lang_supported(
+        #[values("py", "js", "mjs", "jsx", "ts", "tsx")] ext: &str,
+    ) {
+        assert!(
+            super::extension_to_lang(ext).is_some(),
+            "Expected {ext} to map to a language"
+        );
+    }
+
+    #[rstest]
+    fn test_extension_to_lang_unknown(
+        #[values("txt", "md", "", "rs", "java", "cpp")] ext: &str,
+    ) {
+        assert!(
+            super::extension_to_lang(ext).is_none(),
+            "Expected {ext} to not map to any language"
+        );
     }
 
     #[rstest]

--- a/src/hotspot.rs
+++ b/src/hotspot.rs
@@ -58,6 +58,13 @@ fn extension_to_lang(ext: &str) -> Option<LANG> {
     }
 }
 
+fn is_supported_file(path: &Path) -> bool {
+    path.extension()
+        .and_then(|s| s.to_str())
+        .and_then(extension_to_lang)
+        .is_some()
+}
+
 #[derive(Default)]
 pub struct TechDebtHotspots {
     git_base_path: PathBuf,
@@ -106,13 +113,7 @@ impl TechDebtHotspots {
                         paths_to_visit.push(path_to_visit);
                     });
                 }
-                false
-                    if current_path
-                        .extension()
-                        .and_then(|s| s.to_str())
-                        .and_then(extension_to_lang)
-                        .is_some() =>
-                {
+                false if is_supported_file(&current_path) => {
                     self.stats.insert(
                         current_path.to_path_buf(),
                         FileStats {
@@ -349,6 +350,41 @@ mod tests {
         assert!(
             super::extension_to_lang(ext).is_none(),
             "Expected {ext} to not map to any language"
+        );
+    }
+
+    #[rstest]
+    fn test_get_stats_from_filename_parses_supported_languages(
+        #[values("py", "js", "ts", "tsx")] ext: &str,
+    ) {
+        let temp_dir = tempdir().unwrap();
+        let source = match ext {
+            "py" => "x = 1\ny = 2\nprint(x + y)\n",
+            "js" => "const x = 1;\nconst y = 2;\nconsole.log(x + y);\n",
+            "ts" => "const x: number = 1;\nconst y: number = 2;\nconsole.log(x + y);\n",
+            "tsx" => "const x: number = 1;\nconst y: number = 2;\nconsole.log(x + y);\n",
+            _ => "",
+        };
+
+        let path = temp_dir.path().join(format!("test.{ext}"));
+        fs::write(&path, source).unwrap();
+
+        let mut file_stats = FileStats {
+            path: path.clone(),
+            ..Default::default()
+        };
+
+        TechDebtHotspots::get_stats_from_filename(&mut file_stats);
+
+        assert!(
+            file_stats.loc > 0,
+            "Expected loc > 0 for .{ext}, got {}",
+            file_stats.loc
+        );
+        assert!(
+            file_stats.maintainability_index > 0.0,
+            "Expected maintainability_index > 0 for .{ext}, got {}",
+            file_stats.maintainability_index
         );
     }
 

--- a/src/hotspot.rs
+++ b/src/hotspot.rs
@@ -106,11 +106,13 @@ impl TechDebtHotspots {
                         paths_to_visit.push(path_to_visit);
                     });
                 }
-                false if current_path
-                    .extension()
-                    .and_then(|s| s.to_str())
-                    .and_then(extension_to_lang)
-                    .is_some() => {
+                false
+                    if current_path
+                        .extension()
+                        .and_then(|s| s.to_str())
+                        .and_then(extension_to_lang)
+                        .is_some() =>
+                {
                     self.stats.insert(
                         current_path.to_path_buf(),
                         FileStats {
@@ -343,9 +345,7 @@ mod tests {
     }
 
     #[rstest]
-    fn test_extension_to_lang_unknown(
-        #[values("txt", "md", "", "rs", "java", "cpp")] ext: &str,
-    ) {
+    fn test_extension_to_lang_unknown(#[values("txt", "md", "", "rs", "java", "cpp")] ext: &str) {
         assert!(
             super::extension_to_lang(ext).is_none(),
             "Expected {ext} to not map to any language"


### PR DESCRIPTION
## Summary

- Add `js`, `mjs`, `jsx`, `ts`, and `tsx` to the supported file extensions for hotspot analysis
- Replace hard-coded `PythonParser` with language-agnostic dispatch via `get_function_spaces(&LANG, ...)`
- Remove unused `rustpython-parser` dependency
- Add parameterized tests for `extension_to_lang` and multi-language filename collection

The existing `rust-code-analysis` crate already bundles tree-sitter parsers for all these languages, so no new dependencies are required.

Closes #99